### PR TITLE
getDirtyTables support non AI PK

### DIFF
--- a/src/Sniffer/MysqlTableSniffer.php
+++ b/src/Sniffer/MysqlTableSniffer.php
@@ -29,7 +29,7 @@ class MysqlTableSniffer extends BaseTableSniffer
             WHERE
                 TABLE_SCHEMA = DATABASE()
                 AND table_name NOT LIKE '%phinxlog'
-                AND AUTO_INCREMENT > 1;
+                AND TABLE_ROWS > 0;
         ");
     }
 


### PR DESCRIPTION
Tables with non auto-increment columns weren't removed (eg. uuid as pk)