### PR TITLE
#7 Removes the CakePHP fixture init (#9)

### DIFF
--- a/src/FixtureManager.php
+++ b/src/FixtureManager.php
@@ -45,9 +45,7 @@ class FixtureManager extends BaseFixtureManager
      */
     public function __construct()
     {
-        $this
-            ->initDb()
-            ->loadConfig();
+        $this->loadConfig();
     }
 
     /**
@@ -57,12 +55,6 @@ class FixtureManager extends BaseFixtureManager
     public function getConnection($name = 'test')
     {
         return ConnectionManager::get($name);
-    }
-
-    public function initDb(): FixtureManager
-    {
-        $this->_initDb();
-        return $this;
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -58,6 +58,10 @@ define('CONFIG', TEST_APP . 'config' . DS);
 
 require_once CORE_PATH . 'config/bootstrap.php';
 
+# For testing purpose, initiate the FixtureManager first
+# This is not required.
+new \CakephpTestSuiteLight\FixtureManager();
+
 date_default_timezone_set('UTC');
 mb_internal_encoding('UTF-8');
 


### PR DESCRIPTION
Co-authored-by: Juan Pablo Ramirez <>