### PR TITLE
#14 cake3 make perm mode default (#15)

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -13,7 +13,7 @@ export DB_DRIVER=$DRIVER
 #######################
 #### Tests with non temporary sniffers
 #######################
-export SNIFFERS_IN_MAIN_MODE="true"
+export SNIFFERS_IN_TEMP_MODE="true"
 ./vendor/bin/phpunit
 
 #### DEPRECATED #####

--- a/src/Sniffer/BaseTriggerBasedTableSniffer.php
+++ b/src/Sniffer/BaseTriggerBasedTableSniffer.php
@@ -26,9 +26,17 @@ abstract class BaseTriggerBasedTableSniffer extends BaseTableSniffer
 
     const TRIGGER_PREFIX = 'dirty_table_spy_';
 
-    const MAIN_MODE = 'MAIN_MODE';
+    const MODE_KEY = 'dirtyTableCollectorMode';
 
-    const TEMP_MODE = 'TEMP_MODE';
+    /**
+     * The dirty table collector is a permanent table
+     */
+    const PERM_MODE = 'PERM';
+
+    /**
+     * The dirty table collector is a temporary table
+     */
+    const TEMP_MODE = 'TEMP';
 
     /**
      * @var string
@@ -65,24 +73,8 @@ abstract class BaseTriggerBasedTableSniffer extends BaseTableSniffer
      */
     public function __construct(ConnectionInterface $connection)
     {
-        $this->mode = self::TEMP_MODE;
+        $this->mode = $this->getDefaultMode($connection);
         parent::__construct($connection);
-    }
-
-    /**
-     * @return ConnectionInterface
-     */
-    public function getConnection(): ConnectionInterface
-    {
-        return $this->connection;
-    }
-
-    /**
-     * @param ConnectionInterface $connection
-     */
-    public function setConnection(ConnectionInterface $connection)
-    {
-        $this->connection = $connection;
     }
 
     /**
@@ -134,7 +126,9 @@ abstract class BaseTriggerBasedTableSniffer extends BaseTableSniffer
      */
     public function cleanAllTables()
     {
-        $this->markAllTablesAsDirty();
+        if ($this->isInTempMode()) {
+            $this->markAllTablesAsDirty();
+        }
         $this->truncateDirtyTables();
     }
 
@@ -144,7 +138,7 @@ abstract class BaseTriggerBasedTableSniffer extends BaseTableSniffer
      */
     public function activateMainMode()
     {
-        $this->setMode(self::MAIN_MODE);
+        $this->setMode(self::PERM_MODE);
     }
 
     /**
@@ -172,7 +166,8 @@ abstract class BaseTriggerBasedTableSniffer extends BaseTableSniffer
     /**
      * Get the mode on which the sniffer is running
      * This defines if the collector table is
-     * temporary or not
+     * temporary or not.
+     *
      * @return string
      */
     public function getMode(): string
@@ -181,6 +176,24 @@ abstract class BaseTriggerBasedTableSniffer extends BaseTableSniffer
             return '';
         }
         return $this->mode;
+    }
+
+    /**
+     * Defines the default mode for the dirty table collector.
+     *
+     * @param ConnectionInterface $connection
+     * @return string
+     * @throws \Exception
+     */
+    public function getDefaultMode(ConnectionInterface $connection): string
+    {
+        $mode = $connection->config()[self::MODE_KEY] ?? self::PERM_MODE;
+        if (!in_array($mode, [self::TEMP_MODE, self::PERM_MODE])) {
+            $msg = self::MODE_KEY . ' can only be equal to ' . self::PERM_MODE . ' or ' . self::TEMP_MODE;
+            throw new \Exception($msg);
+        }
+
+        return $mode;
     }
 
     /**
@@ -196,6 +209,6 @@ abstract class BaseTriggerBasedTableSniffer extends BaseTableSniffer
      */
     public function isInMainMode(): bool
     {
-        return ($this->getMode() === self::MAIN_MODE);
+        return ($this->getMode() === self::PERM_MODE);
     }
 }

--- a/tests/TestCase/Sniffer/SnifferRegistryTest.php
+++ b/tests/TestCase/Sniffer/SnifferRegistryTest.php
@@ -19,6 +19,7 @@ use Cake\Database\Driver\Postgres;
 use Cake\Database\Driver\Sqlite;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
+use CakephpTestSuiteLight\Sniffer\BaseTriggerBasedTableSniffer;
 use CakephpTestSuiteLight\Sniffer\MysqlTriggerBasedTableSniffer;
 use CakephpTestSuiteLight\Sniffer\PostgresTriggerBasedTableSniffer;
 use CakephpTestSuiteLight\Sniffer\SnifferRegistry;
@@ -63,5 +64,17 @@ class SnifferRegistryTest extends TestCase
         $act = SnifferRegistry::getConnectionSnifferName($connectionName);
         $this->assertSame($sniffer, $act);
         ConnectionManager::drop($connectionName);
+    }
+
+    public function testModeIsCorrect()
+    {
+        $tables = SnifferRegistry::get('test')->fetchAllTables();
+        $collectorIsVisible = in_array(BaseTriggerBasedTableSniffer::DIRTY_TABLE_COLLECTOR, $tables);
+        if (getenv('SNIFFERS_IN_TEMP_MODE') || !SnifferRegistry::get('test')->implementsTriggers()) {
+            $expected = false;
+        } else {
+            $expected = true;
+        }
+        $this->assertSame($expected, $collectorIsVisible);
     }
 }


### PR DESCRIPTION
* #7 Removes the CakePHP fixture init (#9) (#11)

Co-authored-by: Juan Pablo Ramirez <>

* #14 Makes the dirty table collector permanent per default

* #14 Test fix

Co-authored-by: Juan Pablo Ramirez <>