### PR TITLE
Fix: Fix redundant call to `truncateDirtyTables`

### DIFF
--- a/src/Sniffer/BaseTriggerBasedTableSniffer.php
+++ b/src/Sniffer/BaseTriggerBasedTableSniffer.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
  */
 namespace CakephpTestSuiteLight\Sniffer;
 
-
 use Cake\Database\Exception;
 use Cake\Datasource\ConnectionInterface;
 
@@ -129,7 +128,6 @@ abstract class BaseTriggerBasedTableSniffer extends BaseTableSniffer
         if ($this->isInTempMode()) {
             $this->markAllTablesAsDirty();
         }
-        $this->truncateDirtyTables();
     }
 
     /**


### PR DESCRIPTION
Hi,

I've noticed that the truncation was done twice when starting a tests run : 1 requested by FixtureInjector at first test start and 1 more done just before at sniffer start. This PR removes the redundant call by using only the FixtureInjector call. If truncation is delayed by trait, it will occurs at next test case (and so on).