### PR TITLE
Handling table names with hyphens while creating triggers

### DIFF
--- a/src/Sniffer/MysqlTriggerBasedTableSniffer.php
+++ b/src/Sniffer/MysqlTriggerBasedTableSniffer.php
@@ -54,7 +54,7 @@ class MysqlTriggerBasedTableSniffer extends BaseTriggerBasedTableSniffer
         $stmts = "";
         foreach ($this->getAllTablesExceptPhinxlogsAndCollector(true) as $table) {
             $stmts .= "       
-            CREATE TRIGGER {$this->getTriggerName($table)} AFTER INSERT ON `{$table}`
+            CREATE TRIGGER `{$this->getTriggerName($table)}` AFTER INSERT ON `{$table}`
             FOR EACH ROW                
                 INSERT IGNORE INTO {$this->collectorName()} VALUES ('{$table}');                
             ";


### PR DESCRIPTION
Fix triggers creation failing for all the tables after the table name containing hyphen in it.

The trigger creation statement corrupts when the table name contains a hyphen in it. This change fixes the issue. 